### PR TITLE
fix: add property to read docker secrets

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'it.andmora.expensesmonitor'
-version = '0.5.2'
+version = '0.5.3'
 sourceCompatibility = '17'
 
 configurations {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -6,6 +6,9 @@ spring:
     password: ${DB_BACKEND_PASSWORD:postgres}
     pool.validation-query: SELECT 1
 
+  config:
+    import: "optional:configtree:/run/secrets/"
+
 server:
   port: 8443
   ssl:


### PR DESCRIPTION
## Describe your changes
This PR proposes to add the property responsible to read the docker secrets from the /run/secrets directory.
## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
