### PR TITLE
fix: change path to provision grafana dashboards

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -57,5 +57,5 @@ RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
     fi
 
 COPY ./provisioning /etc/grafana/provisioning
-COPY ./dashboards /var/lib/grafana/dashboards
+COPY ./dashboards /etc/grafana/dashboards
 COPY ./grafana.ini /etc/grafana/grafana.ini

--- a/grafana/provisioning/dashboards/all.yml
+++ b/grafana/provisioning/dashboards/all.yml
@@ -6,4 +6,4 @@ providers:
     folder: ''
     type: 'file'
     options:
-      path: '/var/lib/grafana/dashboards'
+      path: '/etc/grafana/dashboards'


### PR DESCRIPTION
## Describe your changes
This PR proposes to change the path to provision the grafana dashboards since it is overwritten by docker volume
## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
