### PR TITLE
fix: user permission to read certificates

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,15 +3,16 @@ FROM gradle:jdk17@sha256:5f4ab273b15961c5f22969136ea884ca0343f1d8b2df5c4c6fe0ca8
 WORKDIR /build
 COPY . .
 
-RUN ./gradlew bootJar --no-daemon
+RUN ./gradlew bootJar --no-daemon -x test
 
 FROM amazoncorretto:17.0.8-alpine3.18@sha256:0c61f12abfb091be48474e836e6802ff3a93e8e038e0460af8c7f447ccbd3901 AS runtime
 
+RUN adduser -D 472
 WORKDIR /app
 
 COPY --from=build /build/build/libs/*.jar /app/app.jar
-RUN chown -R nobody:nobody /app
+RUN chown -R 472:472 /app
 
-USER 65534
+USER 472
 
 ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-Djava.security.egd=file:/dev/./urandom","-jar","/app/app.jar"]

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'it.andmora.expensesmonitor'
-version = '0.5.4'
+version = '0.5.9'
 sourceCompatibility = '17'
 
 configurations {


### PR DESCRIPTION
## Describe your changes
This PR proposes to fix the user permission in Dockerfile to enable the read of TLS certs
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
