### PR TITLE
feat: add wait step into deploy workflow

### DIFF
--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -93,3 +93,14 @@ jobs:
             cd expenses-monitor/${{ inputs.folder }}
             wget -O docker-compose.yml https://raw.githubusercontent.com/and-mora/expenses-monitor/${{ inputs.version }}/${{ inputs.folder }}/docker-compose.yml
             sudo tag=${{ inputs.version }} docker stack deploy --compose-file docker-compose.yml ${{ inputs.folder }}
+
+      - name: 'Docker stack wait till healthy'
+        uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USERNAME }}
+          key: ${{ secrets.VM_PRIVATE_KEY }}
+          port: ${{ secrets.VM_PORT }}
+          fingerprint: ${{ secrets.HOST_FINGERPRINT }}
+          script: |
+            sudo sudo docker run --rm -v /var/run/docker.sock:/var/run/docker.sock sudobmitch/docker-stack-wait@sha256:cb4d86cbf40eea6183db29dc341a7aae9e8196acf9315b863f939540b911d3bb ${{ inputs.folder }}


### PR DESCRIPTION
## Describe your changes
This PR proposes to add a step to wait till the deploy of a component is completed. This helps to run the api test when the component is ready and healthy.
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
