### PR TITLE
fix: [EM-178] add docs for login procedure and grant no downtime in deploy 

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,3 +6,23 @@ The following docker secrets must be present:
 - `BASIC_AUTH_USERNAME`
 - `BASIC_AUTH_PASSWORD`
 - `DB_BACKEND_PASSWORD`
+
+### Login API
+
+To login run:
+```
+curl --location 'https://expmonitor.freeddns.org:8443/login' \
+--header 'Content-Type: application/x-www-form-urlencoded' \
+--data-urlencode 'username=user' \
+--data-urlencode 'password=pwd'
+```
+The response contains a `SESSION` cookie
+```
+Set-Cookie: "SESSION=session-cookie; Path=/; Secure; HttpOnly; SameSite=Lax"
+```
+that must be used in every API call in order to be authenticated.
+
+To logout run: 
+```
+curl --location --request POST 'https://expmonitor.freeddns.org:8443/logout'
+```

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'it.andmora.expensesmonitor'
-version = '0.6.1'
+version = '0.6.2'
 sourceCompatibility = '17'
 
 configurations {

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         max_attempts: 3
       update_config:
         failure_action: rollback
+        order: start-first
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "https://localhost:8443/actuator/health", "--no-check-certificate" ]
       interval: 30s


### PR DESCRIPTION
## Describe your changes
This PR proposes to update the docker compose update configuration to grant no downtime in deployments.
Plus update the readme for login api
## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
