### PR TITLE
fix(grafana): healthcheck api with wrong port

### DIFF
--- a/grafana/docker-compose.yml
+++ b/grafana/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         failure_action: rollback
         order: start-first
     healthcheck:
-      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "https://localhost:8443/api/health", "--no-check-certificate" ]
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "https://localhost:3000/api/health", "--no-check-certificate" ]
       interval: 10s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Describe your changes
This PR proposes to fix the healthcheck url api 
## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
