### PR TITLE
fix(grafana): add secret to mount for smtp server

### DIFF
--- a/grafana/docker-compose.yml
+++ b/grafana/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     environment:
       DATABASE: postgres
       DB_GRAFANA_USERNAME: grafana_user
-    entrypoint: [ '/bin/sh', '-c', 'export DB_GRAFANA_PASSWORD=$$(cat /run/secrets/DB_GRAFANA_PASSWORD); /run.sh' ]
+    entrypoint: [ '/bin/sh', '-c', 'export DB_GRAFANA_PASSWORD=$$(cat /run/secrets/DB_GRAFANA_PASSWORD); export GF_SMTP_PASSWORD=$$(cat /run/secrets/GMAIL_PASSWORD); /run.sh' ]
     ports:
       - '3000:3000'
     volumes:
@@ -30,9 +30,12 @@ services:
       - expenses_monitor
     secrets:
       - DB_GRAFANA_PASSWORD
+      - GMAIL_PASSWORD
 
 secrets:
   DB_GRAFANA_PASSWORD:
+    external: true
+  GMAIL_PASSWORD:
     external: true
 
 volumes:


### PR DESCRIPTION
## Describe your changes
This PR proposes to update the docker compose to mount the smtp secret in order to connect
## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
