### PR TITLE
fix: Refine UI details in payment creation

### DIFF
--- a/frontend/src/app/interfaces/add-payment/add-payment.component.css
+++ b/frontend/src/app/interfaces/add-payment/add-payment.component.css
@@ -39,7 +39,8 @@ mat-form-field {
 .tag-item mat-form-field {
     flex: 1;
     margin-right: 8px;
-    width: 10px; /* This is a hack to make the input field take up the remaining space */
+    /* This is a hack to make the input field take up the remaining space */
+    width: 10px;
 }
 
 .no-tags-message {
@@ -69,4 +70,13 @@ mat-form-field {
     flex-direction: column;
     align-items: center;
     justify-content: center;
+}
+
+.select-placeholder-container {
+    display: flex;
+    align-items: center;
+}
+
+.select-placeholder-container>span {
+    flex: 1;
 }

--- a/frontend/src/app/interfaces/add-payment/add-payment.component.css
+++ b/frontend/src/app/interfaces/add-payment/add-payment.component.css
@@ -5,7 +5,7 @@
 }
 
 .form {
-    padding: 20px;
+    padding: 10px;
     max-width: 400px;
 }
 
@@ -40,4 +40,33 @@ mat-form-field {
     flex: 1;
     margin-right: 8px;
     width: 10px; /* This is a hack to make the input field take up the remaining space */
+}
+
+.no-tags-message {
+    color: lightgrey;
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+.tags-form-buttons {
+    margin: 10px;
+}
+
+.tags-form-buttons button {
+    margin: 10px 5px;
+}
+
+.green-icon {
+    color: green;
+    font-size: 48px;
+    font-weight: bold;
+    height: 48px;
+    width: 48px;
+}
+
+.success-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
 }

--- a/frontend/src/app/interfaces/add-payment/add-payment.component.html
+++ b/frontend/src/app/interfaces/add-payment/add-payment.component.html
@@ -54,7 +54,7 @@
                         <textarea matInput formControlName="description"></textarea>
                     </mat-form-field>
                     <div>
-                        <button mat-button matStepperNext>Avanti</button>
+                        <button mat-raised-button matStepperNext>Avanti</button>
                     </div>
                 </form>
             </div>
@@ -68,6 +68,9 @@
                     Tag
                 </button>
                 <form [formGroup]="tagsForm" class="form">
+                    <div *ngIf="tags.length === 0" class="no-tags-message">
+                        <span>Nessun tag inserito</span>
+                    </div>
                     <div formArrayName="tags">
                         <div *ngFor="let tag of tags.controls; let i=index" [formGroupName]="i" class="tag-item">
                             <mat-form-field appearance="outline">
@@ -83,10 +86,10 @@
                             </button>
                         </div>
                     </div>
-                    <div>
-                        <button mat-button matStepperPrevious>Back</button>
-                        <button mat-button (click)="stepper.reset()">Reset</button>
-                        <button mat-raised-button (click)="onSubmit()" matStepperNext color="primary" type="submit" 
+                    <div class="tags-form-buttons">
+                        <button mat-raised-button matStepperPrevious>Back</button>
+                        <button mat-raised-button (click)="stepper.reset()">Reset</button>
+                        <button mat-raised-button (click)="onSubmit(stepper)" color="primary" type="submit"
                             [disabled]="!addPaymentForm.valid || !tagsForm.valid">Aggiungi pagamento</button>
                     </div>
                 </form>
@@ -96,10 +99,13 @@
         <mat-step>
             <ng-template matStepLabel>Completato</ng-template>
             <div class="centered-text">
-                <h1 *ngIf="!errorMessage">Il pagamento è stato inserito con successo!</h1>
+                <h1 class="success-message" *ngIf="!errorMessage">
+                    Il pagamento è stato inserito con successo!
+                    <mat-icon class="green-icon">done</mat-icon>
+                </h1>
                 <mat-error class="centered-text" *ngIf="errorMessage">{{ errorMessage }}</mat-error>
                 <button mat-raised-button color="primary" (click)="stepper.reset()">Aggiungi un altro pagamento</button>
             </div>
-        </mat-step> 
+        </mat-step>
     </mat-stepper>
 </div>

--- a/frontend/src/app/interfaces/add-payment/add-payment.component.html
+++ b/frontend/src/app/interfaces/add-payment/add-payment.component.html
@@ -7,38 +7,68 @@
                     <mat-form-field appearance="outline">
                         <mat-label>Esercente</mat-label>
                         <input matInput formControlName="merchantName">
-                        <mat-error *ngIf="hasError('merchantName', 'required')">Campo obbligatorio.</mat-error>
+                        @if (hasError('merchantName', 'required')) {
+                        <mat-error>Campo obbligatorio.</mat-error>
+                        }
                     </mat-form-field>
                     <mat-form-field appearance="outline" floatLabel="always">
                         <mat-label>Importo</mat-label>
                         <input matInput type="number" class="right-align" placeholder="0,00" formControlName="amount">
                         <span matTextPrefix>€&nbsp;</span>
-                        <mat-error *ngIf="hasError('amount', 'required')">Campo obbligatorio.</mat-error>
-                        <mat-error *ngIf="hasError('amount', 'min')">
-                            Numero positivo richiesto.
-                        </mat-error>
+                        @if (hasError('amount', 'required')) {
+                        <mat-error>Campo obbligatorio.</mat-error>
+                        }
+                        @if (hasError('amount', 'min')) {
+                        <mat-error>Numero positivo richiesto.</mat-error>
+                        }
                     </mat-form-field>
                     <mat-radio-group aria-label="Select an option" formControlName="type">
                         <mat-radio-button value="1">Income</mat-radio-button>
                         <mat-radio-button value="-1">Outcome</mat-radio-button>
                     </mat-radio-group>
                     <mat-form-field appearance="outline">
+                        @if (isCategoriesLoading) {
+                        <mat-label>
+                            <div class="select-placeholder-container">
+                                <span>Loading... </span>
+                                <mat-spinner diameter="24"></mat-spinner>
+                            </div>
+                        </mat-label>
+                        }
+                        @else {
                         <mat-label>Categoria</mat-label>
-                        <input matInput placeholder="Pick one" formControlName="category" [matAutocomplete]="catAuto">
-                        <mat-error *ngIf="hasError('category', 'required')">Campo obbligatorio.</mat-error>
+                        }
+                        <input matInput placeholder="Scegli una categoria" formControlName="category" [matAutocomplete]="catAuto">
+                        @if (hasError('category', 'required')) {
+                        <mat-error>Campo obbligatorio.</mat-error>
+                        }
                         <mat-autocomplete autoActiveFirstOption #catAuto="matAutocomplete">
-                            <mat-option *ngFor="let option of filteredCategories | async"
-                                [value]="option">{{option}}</mat-option>
+                            @for (option of filteredCategories | async; track option) {
+                            <mat-option [value]="option">{{option}}</mat-option>
+                            }
                         </mat-autocomplete>
                     </mat-form-field>
                     <mat-form-field appearance="outline">
+                        @if (isWalletLoading) {
+                        <mat-label>
+                            <div class="select-placeholder-container">
+                                <span>Loading... </span>
+                                <mat-spinner diameter="24"></mat-spinner>
+                            </div>
+                        </mat-label>
+                        }
+                        @else {
                         <mat-label>Wallet</mat-label>
-                        <input matInput placeholder="Pick one" formControlName="wallet" [matAutocomplete]="walAuto">
-                        <mat-error *ngIf="hasError('wallet', 'required')">Campo obbligatorio.</mat-error>
-                        <mat-autocomplete autoActiveFirstOption #walAuto="matAutocomplete">
-                            <mat-option *ngFor="let option of filteredWallets | async"
-                                [value]="option">{{option}}</mat-option>
-                        </mat-autocomplete>
+                        }
+
+                        <mat-select formControlName="wallet" placeholder="Scegli un Wallet">
+                            @for (wallet of wallets; track wallet) {
+                            <mat-option [value]="wallet">{{wallet.name}}</mat-option>
+                            }
+                        </mat-select>
+                        @if (hasError('wallet', 'required')) {
+                        <mat-error>Campo obbligatorio</mat-error>
+                        }
                     </mat-form-field>
                     <mat-form-field appearance="outline">
                         <mat-label>Data esecuzione</mat-label>
@@ -46,8 +76,10 @@
                         <mat-hint>DD/MM/YYYY</mat-hint>
                         <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
                         <mat-datepicker #picker></mat-datepicker>
-                        <mat-error *ngIf="hasError('accountingDate', 'required')">Campo
+                        @if (hasError('accountingDate', 'required')) {
+                        <mat-error>Campo
                             obbligatorio.</mat-error>
+                        }
                     </mat-form-field>
                     <mat-form-field appearance="outline">
                         <mat-label>Descrizione</mat-label>
@@ -68,11 +100,14 @@
                     Tag
                 </button>
                 <form [formGroup]="tagsForm" class="form">
-                    <div *ngIf="tags.length === 0" class="no-tags-message">
+                    @if (tags.length === 0) {
+                    <div class="no-tags-message">
                         <span>Nessun tag inserito</span>
                     </div>
+                    }
                     <div formArrayName="tags">
-                        <div *ngFor="let tag of tags.controls; let i=index" [formGroupName]="i" class="tag-item">
+                        @for (tag of tags.controls; track tag; let i = $index) {
+                        <div [formGroupName]="i" class="tag-item">
                             <mat-form-field appearance="outline">
                                 <mat-label>Key</mat-label>
                                 <input matInput formControlName="key">
@@ -85,6 +120,7 @@
                                 <mat-icon>delete</mat-icon>
                             </button>
                         </div>
+                        }
                     </div>
                     <div class="tags-form-buttons">
                         <button mat-raised-button matStepperPrevious>Back</button>
@@ -99,11 +135,15 @@
         <mat-step>
             <ng-template matStepLabel>Completato</ng-template>
             <div class="centered-text">
-                <h1 class="success-message" *ngIf="!errorMessage">
+                @if (!errorMessage) {
+                <h1 class="success-message">
                     Il pagamento è stato inserito con successo!
                     <mat-icon class="green-icon">done</mat-icon>
                 </h1>
-                <mat-error class="centered-text" *ngIf="errorMessage">{{ errorMessage }}</mat-error>
+                }
+                @if (errorMessage) {
+                <mat-error class="centered-text">{{ errorMessage }}</mat-error>
+                }
                 <button mat-raised-button color="primary" (click)="stepper.reset()">Aggiungi un altro pagamento</button>
             </div>
         </mat-step>

--- a/frontend/src/app/interfaces/add-payment/add-payment.component.ts
+++ b/frontend/src/app/interfaces/add-payment/add-payment.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
@@ -10,7 +10,9 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatStepper, MatStepperModule } from '@angular/material/stepper';
 import { map, Observable } from 'rxjs';
@@ -26,8 +28,7 @@ import { DialogLoaderComponent } from '../dialog-loader/dialog-loader.component'
   providers: [provideNativeDateAdapter(),
   { provide: MAT_DATE_LOCALE, useValue: 'it-IT' }
   ],
-  imports: [AsyncPipe, NgIf, NgFor, ReactiveFormsModule, MatFormFieldModule, MatButtonModule, MatDatepickerModule, MatInputModule,
-    MatCardModule, MatRadioModule, MatAutocompleteModule, MatIconModule, MatStepperModule]
+  imports: [AsyncPipe, ReactiveFormsModule, MatFormFieldModule, MatButtonModule, MatDatepickerModule, MatInputModule, MatCardModule, MatRadioModule, MatAutocompleteModule, MatIconModule, MatStepperModule, MatProgressSpinnerModule, MatSelectModule]
 })
 export class AddPaymentComponent implements OnInit {
   errorMessage: string = '';
@@ -35,6 +36,8 @@ export class AddPaymentComponent implements OnInit {
   filteredCategories!: Observable<string[]>;
   wallets: WalletDto[] = [];
   filteredWallets!: Observable<string[]>;
+  isWalletLoading: boolean = false;
+  isCategoriesLoading: boolean = false;
 
   addPaymentForm: FormGroup;
   tagsForm: FormGroup;
@@ -57,6 +60,7 @@ export class AddPaymentComponent implements OnInit {
 
   ngOnInit(): void {
     // retrieve categories from the backend
+    this.isCategoriesLoading = true;
     this.apiService.getCategories()
       .subscribe({
         next: a => {
@@ -65,6 +69,7 @@ export class AddPaymentComponent implements OnInit {
         complete: () => {
           // workaround to make it refresh the filteredCategories at component startup
           this.addPaymentForm.get('category')?.setValue('');
+          this.isCategoriesLoading = false;
         }
       });
     // filter the categories to show based on what the user types in the form
@@ -75,11 +80,13 @@ export class AddPaymentComponent implements OnInit {
           return this._filter(value || "");
         }));
     // retrieve wallets from the backend
+    this.isWalletLoading = true;
     this.apiService.getWallets()
       .subscribe({
         next: a => {
           console.log("wallets", a);
           this.wallets = a;
+          this.isWalletLoading = false;
         },
         complete: () => {
           // workaround to make it refresh the filteredCategories at component startup

--- a/frontend/src/app/interfaces/add-payment/add-payment.component.ts
+++ b/frontend/src/app/interfaces/add-payment/add-payment.component.ts
@@ -12,7 +12,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatStepperModule } from '@angular/material/stepper';
+import { MatStepper, MatStepperModule } from '@angular/material/stepper';
 import { map, Observable } from 'rxjs';
 import { PaymentDto } from '../../model/payment';
 import { WalletDto } from '../../model/wallet';
@@ -124,7 +124,7 @@ export class AddPaymentComponent implements OnInit {
     this.tags.removeAt(index);
   }
 
-  onSubmit(): void {
+  onSubmit(stepper: MatStepper): void {
     this.errorMessage = '';
     console.log("add payment form submitted!", this.addPaymentForm.value);
 
@@ -139,12 +139,8 @@ export class AddPaymentComponent implements OnInit {
     this.apiService.addPayment(paymentDto).subscribe({
       next: response => {
         console.log("payment added.", response);
-        this.resetForm();
+        stepper.next();
         loaderDialog.close();
-
-        this.snackBar.open('Pagamento inserito con successo.', undefined, {
-          duration: 1500
-        });
       },
       error: () => {
         this.errorMessage = "Error in inserting a payment.";
@@ -178,17 +174,4 @@ export class AddPaymentComponent implements OnInit {
     return this.addPaymentForm.get(field)?.hasError(error);
   }
 
-  resetForm(): void {
-    // form.reset() does not work as expected
-    this.addPaymentForm.get('amount')?.reset();
-    this.addPaymentForm.get('amount')?.clearValidators();
-    this.addPaymentForm.get('amount')?.setValue('');
-    this.addPaymentForm.get('category')?.reset();
-    this.addPaymentForm.get('category')?.clearValidators();
-    this.addPaymentForm.get('category')?.setValue('');
-    this.addPaymentForm.get('merchantName')?.reset();
-    this.addPaymentForm.get('merchantName')?.clearValidators();
-    this.addPaymentForm.get('merchantName')?.setValue('');
-    this.addPaymentForm.get('description')?.setValue('');
-  }
 }

--- a/frontend/src/app/interfaces/add-wallet/add-wallet.component.html
+++ b/frontend/src/app/interfaces/add-wallet/add-wallet.component.html
@@ -10,13 +10,17 @@
           <mat-form-field appearance="outline">
             <mat-label>Nome Wallet</mat-label>
             <input matInput formControlName="name">
-            <mat-error *ngIf="hasError('name', 'required')">Campo obbligatorio.</mat-error>
+            @if (hasError('name', 'required')) {
+              <mat-error>Campo obbligatorio.</mat-error>
+            }
           </mat-form-field>
         </mat-card-content>
         <mat-card-actions>
           <button mat-raised-button color="primary" type="submit" [disabled]="!addWalletForm.valid">Aggiungi</button>
         </mat-card-actions>
-        <mat-error class="centered-text" *ngIf="errorMessage">{{ errorMessage }}</mat-error>
+        @if (errorMessage) {
+          <mat-error class="centered-text">{{ errorMessage }}</mat-error>
+        }
       </mat-card>
     </form>
 
@@ -28,19 +32,23 @@
       </mat-card-header>
       <mat-card-content class="wallet-list-card-content">
         <mat-list>
-          <mat-list-item *ngFor="let wallet of wallets | async">
-            <div class="wallet-item">
-              <span class="wallet-name">{{ wallet.name }}</span>
-              <div class="wallet-actions">
-                <button mat-icon-button color="warn" (click)="deleteWallet(wallet)">
-                  <mat-icon>delete</mat-icon>
-                </button>
+          @for (wallet of wallets | async; track wallet) {
+            <mat-list-item>
+              <div class="wallet-item">
+                <span class="wallet-name">{{ wallet.name }}</span>
+                <div class="wallet-actions">
+                  <button mat-icon-button color="warn" (click)="deleteWallet(wallet)">
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                </div>
               </div>
-            </div>
-          </mat-list-item>
+            </mat-list-item>
+          }
         </mat-list>
       </mat-card-content>
-      <mat-error class="centered-text" *ngIf="errorMessageWalletList">{{ errorMessageWalletList }}</mat-error>
+      @if (errorMessageWalletList) {
+        <mat-error class="centered-text">{{ errorMessageWalletList }}</mat-error>
+      }
     </mat-card>
   </div>
 </div>

--- a/frontend/src/app/interfaces/add-wallet/add-wallet.component.ts
+++ b/frontend/src/app/interfaces/add-wallet/add-wallet.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -22,8 +22,7 @@ import { DialogLoaderComponent } from '../dialog-loader/dialog-loader.component'
   selector: 'app-add-wallet',
   templateUrl: './add-wallet.component.html',
   styleUrls: ['./add-wallet.component.css'],
-  imports: [AsyncPipe, NgIf, NgFor, ReactiveFormsModule, MatFormFieldModule, MatButtonModule, MatInputModule,
-    MatCardModule, MatTableModule, MatDividerModule, MatListModule, MatIconModule]
+  imports: [AsyncPipe, ReactiveFormsModule, MatFormFieldModule, MatButtonModule, MatInputModule, MatCardModule, MatTableModule, MatDividerModule, MatListModule, MatIconModule]
 })
 export class AddWalletComponent implements OnInit {
   wallets: Observable<WalletDto[]> = new Observable<WalletDto[]>();

--- a/frontend/src/app/interfaces/header/header.component.html
+++ b/frontend/src/app/interfaces/header/header.component.html
@@ -13,14 +13,15 @@
   <button mat-icon-button routerLink="/" class="example-icon favorite-icon" aria-label="Homepage" matTooltip="Homepage">
     <mat-icon>home</mat-icon>
   </button>
-  <div *ngIf="isLoggedIn$ | async; else notLoggedIn">
-    <button mat-icon-button (click)="logout()">
-      <mat-icon>logout</mat-icon>
-    </button>
-  </div>
-  <ng-template #notLoggedIn>
+  @if (isLoggedIn$ | async) {
+    <div>
+      <button mat-icon-button (click)="logout()">
+        <mat-icon>logout</mat-icon>
+      </button>
+    </div>
+  } @else {
     <button mat-icon-button routerLink="login" aria-label="Login">
       <mat-icon>login</mat-icon>
     </button>
-  </ng-template>
+  }
 </mat-toolbar>

--- a/frontend/src/app/interfaces/header/header.component.ts
+++ b/frontend/src/app/interfaces/header/header.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, NgIf } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -12,7 +12,7 @@ import { AuthService } from '../../services/auth.service';
     selector: 'app-header',
     templateUrl: './header.component.html',
     styleUrl: './header.component.css',
-    imports: [RouterLink, AsyncPipe, NgIf, MatToolbarModule, MatButtonModule, MatIconModule, MatSidenavModule]
+    imports: [RouterLink, AsyncPipe, MatToolbarModule, MatButtonModule, MatIconModule, MatSidenavModule]
 })
 export class HeaderComponent {
   @Input() inputSideNav!: MatSidenav;

--- a/frontend/src/app/interfaces/login/login.component.html
+++ b/frontend/src/app/interfaces/login/login.component.html
@@ -16,9 +16,11 @@
       </mat-card-content>
       <mat-card-actions>
         <button mat-raised-button type="submit" color="primary" (click)="login()" [disabled]="isButtonDisabled || !loginForm.valid">
-          Login</button>
+        Login</button>
       </mat-card-actions>
-      <mat-error class="centered-text" *ngIf="errorMessage">{{ errorMessage }}</mat-error>
+      @if (errorMessage) {
+        <mat-error class="centered-text">{{ errorMessage }}</mat-error>
+      }
     </mat-card>
   </form>
 </div>

--- a/frontend/src/app/interfaces/login/login.component.ts
+++ b/frontend/src/app/interfaces/login/login.component.ts
@@ -1,4 +1,4 @@
-import { NgIf } from '@angular/common';
+
 import { Component } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -18,8 +18,7 @@ import { DialogSuccessComponent } from '../dialog-success/dialog-success.compone
     selector: 'app-login',
     templateUrl: './login.component.html',
     styleUrl: './login.component.css',
-    imports: [NgIf, ReactiveFormsModule, MatButtonModule, MatFormFieldModule, MatInputModule, MatIconModule,
-        MatCardModule, MatProgressSpinnerModule]
+    imports: [ReactiveFormsModule, MatButtonModule, MatFormFieldModule, MatInputModule, MatIconModule, MatCardModule, MatProgressSpinnerModule]
 })
 export class LoginComponent {
   loginForm = this.formBuilder.group({

--- a/frontend/src/app/model/payment.ts
+++ b/frontend/src/app/model/payment.ts
@@ -1,4 +1,4 @@
-import { Tag } from "./tag";
+import { TagDto } from "./tag";
 
 export interface PaymentDto {
     merchantName: string;
@@ -7,5 +7,5 @@ export interface PaymentDto {
     accountingDate: string;
     description: string;
     wallet: string;
-    tags: Tag[];
+    tags: TagDto[];
 }

--- a/frontend/src/app/model/tag.ts
+++ b/frontend/src/app/model/tag.ts
@@ -1,4 +1,4 @@
-export interface Tag {
+export interface TagDto {
     key: string;
     value: string;
 }

--- a/frontend_deploy/manifest.yaml
+++ b/frontend_deploy/manifest.yaml
@@ -21,7 +21,7 @@ spec:
             name: frontend-nginx-config
           name: nginx-config
       containers:
-        - image: ghcr.io/and-mora/expenses-monitor:v0.8.1-frontend
+        - image: ghcr.io/and-mora/expenses-monitor:v0.8.2-frontend
           name: frontend
           volumeMounts:
             - mountPath: "/etc/nginx/conf.d"


### PR DESCRIPTION
## Describe your changes
This PR proposes a lot of changes in UI/UX in frontend web page.

- update with `@if @for` notation instead of `ngIf ngFor`
- make last step of payment stepper triggered by http response and add success icon
- loading spinners in form field that requires a query
- improve UI of 2nd step of steppers, tags section
- payment creation form is now being reset only by last step button "aggiungi nuovo pagamento", not by submit.
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
